### PR TITLE
Removing hardcode jwt-secret

### DIFF
--- a/Back-End/re-tac-toe/src/main/resources/application.properties
+++ b/Back-End/re-tac-toe/src/main/resources/application.properties
@@ -9,4 +9,4 @@ frontend.url=${FRONTEND_URL}
 spring.datasource.driver-class-name= org.postgresql.Driver
 spring.jpa.hibernate.ddl-auto=update
 
-jwt.secret=your-256-bit-secret-key-here-make-it-at-least-32bytes-long
+jwt.secret=${JWT_SECRET_KEY}


### PR DESCRIPTION
jwt-secret is hardcoded in application.properties, it is moved into .env for security reasons.